### PR TITLE
force exit on extra interupt

### DIFF
--- a/server/utils/shutdownUtils.js
+++ b/server/utils/shutdownUtils.js
@@ -28,13 +28,13 @@ function setupGracefulShutdown(resources) {
 
   // Handle application termination
   process.on('SIGTERM', async () => {
-    logger.debug('SIGTERM received, shutting down gracefully');
+    logger.info('SIGTERM received, shutting down gracefully (press Ctrl+C again to force exit)...');
     await gracefulShutdown();
   });
 
   // Handle Ctrl+C
   process.on('SIGINT', async () => {
-    logger.debug('SIGINT received, shutting down gracefully');
+    logger.info('SIGINT received, shutting down gracefully (press Ctrl+C again to force exit)...');
     await gracefulShutdown();
   });
 
@@ -55,10 +55,10 @@ function setupGracefulShutdown(resources) {
  * Performs graceful shutdown of application resources
  */
 async function gracefulShutdown() {
-  // Prevent multiple simultaneous shutdown attempts
+  // Second signal forces immediate exit
   if (shuttingDown) {
-    logger.debug('Shutdown already in progress, ignoring duplicate signal');
-    return;
+    logger.warn('Shutdown signal received again, forcing immediate exit!');
+    process.exit(1);
   }
   
   shuttingDown = true;


### PR DESCRIPTION
This pull request improves the application's shutdown process by making shutdown signals more visible in the logs and ensuring that repeated shutdown signals force an immediate exit. These changes help operators better understand the shutdown state and provide a way to force termination if needed.

**Enhancements to graceful shutdown handling:**

* Changed log messages for `SIGTERM` and `SIGINT` signals to use `logger.info` and clarified instructions for forcing exit by pressing Ctrl+C again (`server/utils/shutdownUtils.js`).
* Updated the shutdown logic so that if a shutdown signal is received a second time while a shutdown is already in progress, the application logs a warning and immediately exits, instead of ignoring the duplicate signal (`server/utils/shutdownUtils.js`).